### PR TITLE
Add Flask web UI for interactive tournaments

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,24 @@ docker compose run --rm pd --rounds 200 --repeats 3 --noise 0.03 --continuation 
 ls out
 ```
 
+## Web interface
+
+A lightweight Flask UI is included for exploring tournaments interactively.
+
+```bash
+# Install the package locally (creates a virtualenv if desired)
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+
+# Start the web server
+flask --app app.web run
+
+# Visit http://127.0.0.1:5000/ in your browser
+```
+
+The web UI lets you pick strategies, tweak tournament parameters, and view standings/match breakdowns without leaving the browser.
+
 ## Options
 
 - `--rounds`: Fixed number of rounds per match if `--continuation` is 0. Default 150

--- a/app/cli.py
+++ b/app/cli.py
@@ -1,24 +1,12 @@
-import argparse, csv, json, os, datetime, random
-from typing import List, Type, Dict, Any
-from .engine import Payoffs, play_match
-from . import strategies as S
+import argparse
+import csv
+import datetime
+import json
+import os
+from typing import Any, Dict, List
 
-def resolve_strategies(only: List[str], exclude: List[str]):
-    all_classes: List[Type] = S.ALL_STRATEGIES
-    def canon(x: str) -> str:
-        return x.lower().strip().replace("-", "").replace("_", "")
-    only_c = set(map(canon, only)) if only else None
-    exclude_c = set(map(canon, exclude)) if exclude else set()
-
-    selected = []
-    for cls in all_classes:
-        name = canon(cls.__name__)
-        if only_c is not None and name not in only_c:
-            continue
-        if name in exclude_c:
-            continue
-        selected.append(cls)
-    return selected
+from .engine import Payoffs
+from .tournament import list_available_strategies, run_tournament
 
 def write_csv(path: str, rows: List[Dict[str, Any]]):
     fieldnames = sorted({k for row in rows for k in row.keys()})
@@ -43,8 +31,8 @@ def main():
     args = parser.parse_args()
 
     if args.labels:
-        for cls in S.ALL_STRATEGIES:
-            print(cls.__name__)
+        for info in list_available_strategies():
+            print(info["name"])
         return
 
     only_list = [x for x in args.only.split(",") if x.strip()] if args.only else []
@@ -53,62 +41,35 @@ def main():
     pay = json.loads(args.payoffs)
     payoffs = Payoffs(T=int(pay["T"]), R=int(pay["R"]), P=int(pay["P"]), S=int(pay["S"]))
 
-    rng = random.Random(args.seed)
-
-    strategy_classes = resolve_strategies(only_list, exclude_list)
-    if len(strategy_classes) < 2:
-        raise SystemExit("Need at least two strategies to run a tournament")
+    try:
+        result = run_tournament(
+            rounds=args.rounds,
+            continuation=args.continuation,
+            noise=args.noise,
+            repeats=args.repeats,
+            seed=args.seed,
+            payoffs=payoffs,
+            only=only_list,
+            exclude=exclude_list,
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc))
 
     timestamp = datetime.datetime.utcnow().strftime("%Y%m%d-%H%M%S")
     out_dir = os.environ.get("OUT_DIR", "/out")
     os.makedirs(out_dir, exist_ok=True)
     tag = f"pd_{timestamp}"
-    standings_rows = []
-    all_results = []
-
-    for rep in range(args.repeats):
-        players = [cls() for cls in strategy_classes]
-        names = [p.__class__.__name__ for p in players]
-
-        for i, a in enumerate(players):
-            for j, b in enumerate(players):
-                if j <= i:
-                    continue
-                res = play_match(a, b, rounds=args.rounds, continuation=args.continuation, noise=args.noise, payoffs=payoffs, rng=rng)
-                row_ab = {
-                    "rep": rep,
-                    "A": names[i],
-                    "B": names[j],
-                    "rounds": res["rounds"],
-                    "score_A": res["scores"]["A"],
-                    "score_B": res["scores"]["B"],
-                    "avg_A": round(res["avg"]["A"], 4),
-                    "avg_B": round(res["avg"]["B"], 4),
-                    "history_A": res["history"]["A"],
-                    "history_B": res["history"]["B"],
-                }
-                all_results.append(row_ab)
-
-    totals: Dict[str, float] = {}
-    games: Dict[str, int] = {}
-    for row in all_results:
-        for side in ["A","B"]:
-            name = row[side]
-            score = row[f"score_{side}"]
-            rounds = row["rounds"]
-            totals[name] = totals.get(name, 0.0) + score
-            games[name] = games.get(name, 0) + rounds
-
-    standings = [{"strategy": k, "total_score": totals[k], "total_rounds": games[k], "avg_per_round": round(totals[k]/games[k], 4)} for k in totals]
-    standings.sort(key=lambda r: (-r["avg_per_round"], -r["total_score"], r["strategy"]))
+    matches = result["matches"]
+    standings = result["standings"]
+    strategies = result["strategies"]
 
     if args.format == "csv":
-        write_csv(os.path.join(out_dir, f"{tag}_matches.csv"), all_results)
+        write_csv(os.path.join(out_dir, f"{tag}_matches.csv"), matches)
         write_csv(os.path.join(out_dir, f"{tag}_standings.csv"), standings)
         with open(os.path.join(out_dir, f"{tag}_summary.json"), "w", encoding="utf-8") as f:
             json.dump({
                 "params": vars(args),
-                "strategies": [cls.__name__ for cls in strategy_classes],
+                "strategies": strategies,
                 "standings": standings[:5]
             }, f, indent=2)
         print(f"Done. See CSVs and JSON in {out_dir}")
@@ -116,8 +77,8 @@ def main():
         with open(os.path.join(out_dir, f"{tag}_results.json"), "w", encoding="utf-8") as f:
             json.dump({
                 "params": vars(args),
-                "strategies": [cls.__name__ for cls in strategy_classes],
-                "matches": all_results,
+                "strategies": strategies,
+                "matches": matches,
                 "standings": standings
             }, f, indent=2)
         print(f"Done. See JSON in {out_dir}")

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1,0 +1,218 @@
+const strategiesListEl = document.getElementById('strategiesList');
+const selectAllBtn = document.getElementById('selectAll');
+const clearAllBtn = document.getElementById('clearAll');
+const form = document.getElementById('tournamentForm');
+const statusMessageEl = document.getElementById('statusMessage');
+const resultsWrapper = document.getElementById('results');
+const standingsBody = document.querySelector('#standingsTable tbody');
+const matchesBody = document.querySelector('#matchesTable tbody');
+const matchHintEl = document.getElementById('matchHint');
+const runButton = document.getElementById('runButton');
+const summaryStrategies = document.getElementById('summaryStrategies');
+const summaryRounds = document.getElementById('summaryRounds');
+const summaryRepeats = document.getElementById('summaryRepeats');
+
+const MAX_MATCH_ROWS = 100;
+
+function toNumber(value, fallback) {
+  if (value === null || value === '' || Number.isNaN(Number(value))) {
+    return fallback;
+  }
+  return Number(value);
+}
+
+async function loadStrategies() {
+  try {
+    const response = await fetch('/api/strategies');
+    if (!response.ok) {
+      throw new Error(`Failed to load strategies (${response.status})`);
+    }
+    const data = await response.json();
+    renderStrategies(data.strategies || []);
+  } catch (err) {
+    strategiesListEl.innerHTML = '';
+    const error = document.createElement('p');
+    error.className = 'status';
+    error.textContent = `Error loading strategies: ${err.message}`;
+    strategiesListEl.appendChild(error);
+    selectAllBtn.disabled = true;
+    clearAllBtn.disabled = true;
+  }
+}
+
+function renderStrategies(strategies) {
+  strategiesListEl.innerHTML = '';
+  if (!strategies.length) {
+    const empty = document.createElement('p');
+    empty.className = 'status';
+    empty.textContent = 'No strategies available.';
+    strategiesListEl.appendChild(empty);
+    return;
+  }
+
+  const sorted = [...strategies].sort((a, b) => a.name.localeCompare(b.name));
+  for (const strategy of sorted) {
+    const label = document.createElement('label');
+    label.className = 'strategy-item';
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.name = 'strategies';
+    checkbox.value = strategy.name;
+    checkbox.checked = true;
+
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'strategy-name';
+    nameSpan.textContent = strategy.name;
+
+    const description = document.createElement('span');
+    description.className = 'strategy-description';
+    description.textContent = strategy.description || 'No description provided.';
+
+    label.appendChild(checkbox);
+    label.appendChild(nameSpan);
+    label.appendChild(description);
+    strategiesListEl.appendChild(label);
+  }
+}
+
+function gatherFormData() {
+  const formData = new FormData(form);
+  const selectedStrategies = Array.from(
+    strategiesListEl.querySelectorAll('input[type="checkbox"]:checked')
+  ).map((input) => input.value);
+
+  return {
+    rounds: toNumber(formData.get('rounds'), 150),
+    continuation: toNumber(formData.get('continuation'), 0),
+    noise: toNumber(formData.get('noise'), 0),
+    repeats: toNumber(formData.get('repeats'), 1),
+    seed: formData.get('seed') || null,
+    payoffs: {
+      T: toNumber(formData.get('payoff_T'), 5),
+      R: toNumber(formData.get('payoff_R'), 3),
+      P: toNumber(formData.get('payoff_P'), 1),
+      S: toNumber(formData.get('payoff_S'), 0),
+    },
+    strategies: selectedStrategies,
+  };
+}
+
+function validatePayload(payload) {
+  if (payload.strategies.length < 2) {
+    throw new Error('Select at least two strategies to compare.');
+  }
+  if (payload.rounds < 1) {
+    throw new Error('Rounds must be at least 1.');
+  }
+  if (payload.repeats < 1) {
+    throw new Error('Repeats must be at least 1.');
+  }
+  if (payload.continuation < 0 || payload.continuation > 1) {
+    throw new Error('Continuation probability must be between 0 and 1.');
+  }
+  if (payload.noise < 0 || payload.noise > 1) {
+    throw new Error('Noise probability must be between 0 and 1.');
+  }
+  return payload;
+}
+
+async function submitForm(event) {
+  event.preventDefault();
+  resultsWrapper.classList.add('hidden');
+  statusMessageEl.textContent = 'Running tournament…';
+  runButton.disabled = true;
+  try {
+    const payload = validatePayload(gatherFormData());
+    const response = await fetch('/api/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.json().catch(() => ({}));
+      const message = errorBody.error || `Request failed with status ${response.status}`;
+      throw new Error(message);
+    }
+
+    const result = await response.json();
+    renderResults(result);
+  } catch (err) {
+    statusMessageEl.textContent = err.message;
+  } finally {
+    runButton.disabled = false;
+  }
+}
+
+function renderResults(result) {
+  const standings = result.standings || [];
+  const matches = result.matches || [];
+  const params = result.params || {};
+  const strategies = result.strategies || [];
+
+  summaryStrategies.textContent = strategies.join(', ') || '—';
+  summaryRounds.textContent = params.continuation && params.continuation > 0
+    ? `${params.rounds ?? '—'} (continuation ${params.continuation})`
+    : (params.rounds ?? '—');
+  summaryRepeats.textContent = params.repeats ?? '—';
+
+  standingsBody.innerHTML = '';
+  standings.forEach((row, index) => {
+    const tr = document.createElement('tr');
+    const totalScore = Number(row.total_score ?? 0);
+    const totalRounds = Number(row.total_rounds ?? 0);
+    const average = Number(row.avg_per_round ?? 0);
+    tr.innerHTML = `
+      <td>${index + 1}</td>
+      <td>${row.strategy}</td>
+      <td>${totalScore.toFixed(2)}</td>
+      <td>${totalRounds}</td>
+      <td>${average.toFixed(4)}</td>
+    `;
+    standingsBody.appendChild(tr);
+  });
+
+  matchesBody.innerHTML = '';
+  const limitedMatches = matches.slice(0, MAX_MATCH_ROWS);
+  limitedMatches.forEach((row) => {
+    const tr = document.createElement('tr');
+    const avgA = Number(row.avg_A ?? 0);
+    const avgB = Number(row.avg_B ?? 0);
+    tr.innerHTML = `
+      <td>${row.rep}</td>
+      <td>${row.A}</td>
+      <td>${row.B}</td>
+      <td>${row.score_A}</td>
+      <td>${row.score_B}</td>
+      <td>${avgA.toFixed(4)}</td>
+      <td>${avgB.toFixed(4)}</td>
+      <td>${row.rounds}</td>
+    `;
+    matchesBody.appendChild(tr);
+  });
+
+  if (matches.length > MAX_MATCH_ROWS) {
+    matchHintEl.textContent = `Showing the first ${MAX_MATCH_ROWS} of ${matches.length} matches. Export the results via the CLI for the full dataset.`;
+  } else if (!matches.length) {
+    matchHintEl.textContent = 'No matches were played.';
+  } else {
+    matchHintEl.textContent = '';
+  }
+
+  statusMessageEl.textContent = `Tournament complete: ${matches.length} matches played.`;
+  resultsWrapper.classList.remove('hidden');
+}
+
+function setAllStrategies(checked) {
+  const inputs = strategiesListEl.querySelectorAll('input[type="checkbox"]');
+  inputs.forEach((input) => {
+    input.checked = checked;
+  });
+}
+
+selectAllBtn.addEventListener('click', () => setAllStrategies(true));
+clearAllBtn.addEventListener('click', () => setAllStrategies(false));
+form.addEventListener('submit', submitForm);
+
+loadStrategies();

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,0 +1,249 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  line-height: 1.5;
+  font-size: 16px;
+  background-color: #f5f5f7;
+  color: #1f2933;
+}
+
+body {
+  margin: 0;
+  background: linear-gradient(180deg, #f5f5f7 0%, #e9ecf2 100%);
+}
+
+.hero {
+  background: #192a56;
+  color: #fff;
+  padding: 2.5rem 0;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+}
+
+.hero .subtitle {
+  opacity: 0.85;
+  max-width: 42rem;
+}
+
+.container {
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  max-width: 1200px;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+  margin: -3rem auto 2rem auto;
+}
+
+.card {
+  background: #fff;
+  border-radius: 1rem;
+  box-shadow: 0 20px 60px rgba(25, 42, 86, 0.12);
+  padding: 1.75rem;
+}
+
+.card h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.grid input[type="number"] {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #d6dae5;
+  border-radius: 0.6rem;
+  font-size: 1rem;
+}
+
+.grid input[type="number"]:focus {
+  outline: 2px solid #5165ff;
+  border-color: transparent;
+}
+
+.grid {
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+fieldset {
+  margin-top: 1.5rem;
+  border: 1px solid #dbe1f1;
+  border-radius: 1rem;
+  padding: 1rem;
+}
+
+legend {
+  padding: 0 0.5rem;
+  font-weight: 700;
+}
+
+.strategy-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.strategy-actions button,
+.actions button {
+  background: #5165ff;
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1.25rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.strategy-actions button:hover,
+.actions button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 25px rgba(81, 101, 255, 0.25);
+}
+
+.strategy-actions button:disabled,
+.actions button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.strategy-list {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.strategy-list label {
+  border: 1px solid #dbe1f1;
+  border-radius: 0.8rem;
+  padding: 0.75rem;
+  background: #f8f9ff;
+  display: block;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.strategy-item {
+  display: block;
+}
+
+.strategy-name {
+  display: inline-block;
+  font-weight: 700;
+  margin-right: 0.25rem;
+}
+
+.strategy-description {
+  display: block;
+  font-size: 0.85rem;
+  color: #5a6785;
+  margin-top: 0.25rem;
+}
+
+.strategy-list input[type="checkbox"] {
+  margin-right: 0.5rem;
+}
+
+.strategy-list label:hover {
+  border-color: #5165ff;
+  box-shadow: 0 12px 30px rgba(81, 101, 255, 0.15);
+}
+
+.loading {
+  margin: 0;
+  font-style: italic;
+}
+
+.actions {
+  margin-top: 1.5rem;
+}
+
+.status {
+  margin: 0 0 1rem 0;
+  color: #3d4a62;
+  font-weight: 500;
+}
+
+.summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  background: #f5f7ff;
+  border-radius: 0.8rem;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.summary strong {
+  font-size: 0.95rem;
+}
+
+.tables {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+#standingsTable,
+#matchesTable {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 400px;
+}
+
+#standingsTable th,
+#standingsTable td,
+#matchesTable th,
+#matchesTable td {
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #e3e8f5;
+}
+
+#standingsTable tbody tr:nth-child(even),
+#matchesTable tbody tr:nth-child(even) {
+  background: rgba(81, 101, 255, 0.06);
+}
+
+.hidden {
+  display: none;
+}
+
+.hint {
+  color: #6c7a97;
+  font-size: 0.9rem;
+  margin-top: 0.75rem;
+}
+
+.footer {
+  padding: 2rem 0;
+  text-align: center;
+  font-size: 0.85rem;
+  color: #6c7a97;
+}
+
+@media (max-width: 720px) {
+  .layout {
+    margin-top: -2rem;
+  }
+
+  .card {
+    padding: 1.25rem;
+  }
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,146 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Prisoner's Dilemma Tournament</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body>
+  <header class="hero">
+    <div class="container">
+      <h1>Iterated Prisoner's Dilemma Tournament</h1>
+      <p class="subtitle">Experiment with classic strategies and visualize the results in real time.</p>
+    </div>
+  </header>
+
+  <main class="container layout">
+    <section class="card" id="configCard">
+      <h2>Configure tournament</h2>
+      <form id="tournamentForm">
+        <div class="grid">
+          <label>
+            Rounds
+            <input type="number" name="rounds" min="1" value="150" required>
+          </label>
+          <label>
+            Continuation probability
+            <input type="number" name="continuation" min="0" max="1" step="0.01" value="0">
+          </label>
+          <label>
+            Noise probability
+            <input type="number" name="noise" min="0" max="1" step="0.01" value="0">
+          </label>
+          <label>
+            Repeats
+            <input type="number" name="repeats" min="1" value="1" required>
+          </label>
+          <label>
+            Seed (optional)
+            <input type="number" name="seed" placeholder="random">
+          </label>
+        </div>
+
+        <fieldset class="strategies">
+          <legend>Strategies</legend>
+          <div class="strategy-actions">
+            <button type="button" id="selectAll">Select all</button>
+            <button type="button" id="clearAll">Clear</button>
+          </div>
+          <div id="strategiesList" class="strategy-list" aria-live="polite">
+            <p class="loading">Loading strategies…</p>
+          </div>
+        </fieldset>
+
+        <fieldset class="payoffs">
+          <legend>Payoff matrix</legend>
+          <div class="grid payoff-grid">
+            <label>Temptation (T)
+              <input type="number" name="payoff_T" value="5">
+            </label>
+            <label>Reward (R)
+              <input type="number" name="payoff_R" value="3">
+            </label>
+            <label>Punishment (P)
+              <input type="number" name="payoff_P" value="1">
+            </label>
+            <label>Sucker (S)
+              <input type="number" name="payoff_S" value="0">
+            </label>
+          </div>
+        </fieldset>
+
+        <div class="actions">
+          <button type="submit" id="runButton">Run tournament</button>
+        </div>
+      </form>
+    </section>
+
+    <section class="card" id="resultsCard">
+      <h2>Results</h2>
+      <p id="statusMessage" class="status">Pick some strategies and press “Run tournament”.</p>
+      <div id="results" class="hidden" aria-live="polite">
+        <div class="summary">
+          <div>
+            <strong>Strategies:</strong>
+            <span id="summaryStrategies"></span>
+          </div>
+          <div>
+            <strong>Rounds per match:</strong>
+            <span id="summaryRounds"></span>
+          </div>
+          <div>
+            <strong>Repeats:</strong>
+            <span id="summaryRepeats"></span>
+          </div>
+        </div>
+
+        <div class="tables">
+          <div class="table-wrapper">
+            <h3>Standings</h3>
+            <table id="standingsTable">
+              <thead>
+                <tr>
+                  <th scope="col">Rank</th>
+                  <th scope="col">Strategy</th>
+                  <th scope="col">Total score</th>
+                  <th scope="col">Total rounds</th>
+                  <th scope="col">Avg / round</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+          <div class="table-wrapper">
+            <h3>Match breakdown</h3>
+            <table id="matchesTable">
+              <thead>
+                <tr>
+                  <th scope="col">Rep</th>
+                  <th scope="col">A</th>
+                  <th scope="col">B</th>
+                  <th scope="col">Score A</th>
+                  <th scope="col">Score B</th>
+                  <th scope="col">Avg A</th>
+                  <th scope="col">Avg B</th>
+                  <th scope="col">Rounds</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+            <p class="hint" id="matchHint"></p>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>Built with Flask &amp; vanilla JavaScript. Source available in this repository.</p>
+    </div>
+  </footer>
+
+  <script src="{{ url_for('static', filename='app.js') }}" defer></script>
+</body>
+</html>

--- a/app/tournament.py
+++ b/app/tournament.py
@@ -1,0 +1,143 @@
+"""Shared tournament helpers used by both CLI and the web UI."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import asdict
+from typing import Any, Dict, List, Sequence, Type
+
+from .engine import Payoffs, play_match
+from . import strategies as S
+from .strategies import BaseStrategy
+
+StrategyClass = Type[BaseStrategy]
+
+
+def _canon(name: str) -> str:
+    """Normalize a strategy name for comparisons."""
+    return name.lower().strip().replace("-", "").replace("_", "")
+
+
+def list_available_strategies() -> List[Dict[str, str]]:
+    """Return metadata about all built-in strategies."""
+    items: List[Dict[str, str]] = []
+    for cls in S.ALL_STRATEGIES:
+        items.append({
+            "name": cls.__name__,
+            "description": (cls.__doc__ or "").strip(),
+        })
+    return items
+
+
+def resolve_strategies(only: Sequence[str] | None = None, exclude: Sequence[str] | None = None) -> List[StrategyClass]:
+    """Select strategies based on optional inclusion/exclusion lists."""
+    only_canon = {_canon(x) for x in only} if only else None
+    exclude_canon = {_canon(x) for x in exclude} if exclude else set()
+
+    selected: List[StrategyClass] = []
+    for cls in S.ALL_STRATEGIES:
+        name = _canon(cls.__name__)
+        if only_canon is not None and name not in only_canon:
+            continue
+        if name in exclude_canon:
+            continue
+        selected.append(cls)
+    return selected
+
+
+def run_tournament(
+    *,
+    rounds: int = 150,
+    continuation: float = 0.0,
+    noise: float = 0.0,
+    repeats: int = 1,
+    seed: int | None = None,
+    payoffs: Payoffs | None = None,
+    only: Sequence[str] | None = None,
+    exclude: Sequence[str] | None = None,
+    strategy_classes: Sequence[StrategyClass] | None = None,
+    rng: random.Random | None = None,
+) -> Dict[str, Any]:
+    """Run a full round-robin tournament and return serialized results."""
+    if payoffs is None:
+        payoffs = Payoffs()
+
+    if strategy_classes is None:
+        strategy_classes = resolve_strategies(only=only, exclude=exclude)
+
+    strategy_classes = list(strategy_classes)
+    if len(strategy_classes) < 2:
+        raise ValueError("Need at least two strategies to run a tournament")
+
+    if rng is None:
+        rng = random.Random(seed)
+    else:
+        if seed is not None:
+            rng.seed(seed)
+
+    matches: List[Dict[str, Any]] = []
+
+    totals: Dict[str, float] = {}
+    rounds_played: Dict[str, int] = {}
+
+    for rep in range(max(1, repeats)):
+        players = [cls() for cls in strategy_classes]
+        names = [p.__class__.__name__ for p in players]
+
+        for i, player_a in enumerate(players):
+            for j, player_b in enumerate(players):
+                if j <= i:
+                    continue
+                result = play_match(
+                    player_a,
+                    player_b,
+                    rounds=rounds,
+                    continuation=continuation,
+                    noise=noise,
+                    payoffs=payoffs,
+                    rng=rng,
+                )
+                row = {
+                    "rep": rep,
+                    "A": names[i],
+                    "B": names[j],
+                    "rounds": result["rounds"],
+                    "score_A": result["scores"]["A"],
+                    "score_B": result["scores"]["B"],
+                    "avg_A": round(result["avg"]["A"], 4),
+                    "avg_B": round(result["avg"]["B"], 4),
+                    "history_A": result["history"]["A"],
+                    "history_B": result["history"]["B"],
+                }
+                matches.append(row)
+
+                totals[names[i]] = totals.get(names[i], 0.0) + row["score_A"]
+                totals[names[j]] = totals.get(names[j], 0.0) + row["score_B"]
+                rounds_played[names[i]] = rounds_played.get(names[i], 0) + row["rounds"]
+                rounds_played[names[j]] = rounds_played.get(names[j], 0) + row["rounds"]
+
+    standings = [
+        {
+            "strategy": name,
+            "total_score": totals[name],
+            "total_rounds": rounds_played[name],
+            "avg_per_round": round(totals[name] / rounds_played[name], 4) if rounds_played[name] else 0.0,
+        }
+        for name in totals
+    ]
+    standings.sort(key=lambda r: (-r["avg_per_round"], -r["total_score"], r["strategy"]))
+
+    result: Dict[str, Any] = {
+        "params": {
+            "rounds": rounds,
+            "continuation": continuation,
+            "noise": noise,
+            "repeats": repeats,
+            "seed": seed,
+            "payoffs": asdict(payoffs),
+        },
+        "strategies": [cls.__name__ for cls in strategy_classes],
+        "matches": matches,
+        "standings": standings,
+    }
+    return result

--- a/app/web.py
+++ b/app/web.py
@@ -1,0 +1,70 @@
+"""Flask application providing a simple web UI for tournaments."""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+from flask import Flask, jsonify, render_template, request
+
+from .engine import Payoffs
+from .tournament import list_available_strategies, run_tournament
+
+
+def create_app() -> Flask:
+    app = Flask(__name__, static_folder="static", template_folder="templates")
+
+    @app.get("/")
+    def index() -> str:
+        return render_template("index.html")
+
+    @app.get("/api/strategies")
+    def api_strategies():
+        return jsonify({"strategies": list_available_strategies()})
+
+    @app.post("/api/run")
+    def api_run():
+        payload: Dict[str, Any] = request.get_json(silent=True) or {}
+        try:
+            rounds = int(payload.get("rounds", 150))
+            continuation = float(payload.get("continuation", 0.0))
+            noise = float(payload.get("noise", 0.0))
+            repeats = int(payload.get("repeats", 1))
+            seed = payload.get("seed")
+            seed = int(seed) if seed not in (None, "") else None
+
+            payoff_data = payload.get("payoffs") or {}
+            payoffs = Payoffs(
+                T=int(payoff_data.get("T", 5)),
+                R=int(payoff_data.get("R", 3)),
+                P=int(payoff_data.get("P", 1)),
+                S=int(payoff_data.get("S", 0)),
+            )
+
+            selected = payload.get("strategies") or None
+            exclude = payload.get("exclude") or None
+
+            result = run_tournament(
+                rounds=rounds,
+                continuation=continuation,
+                noise=noise,
+                repeats=repeats,
+                seed=seed,
+                payoffs=payoffs,
+                only=selected,
+                exclude=exclude,
+            )
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+        except Exception as exc:  # pragma: no cover - generic safeguard
+            return jsonify({"error": "Failed to run tournament", "details": str(exc)}), 500
+
+        return jsonify(result)
+
+    return app
+
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 5000)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,22 @@ description = "Dockerized Iterated Prisoner's Dilemma tournament"
 authors = [{name="You"}]
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = []
+dependencies = [
+    "Flask>=2.3",
+]
 
 [tool.setuptools.package-dir]
 "" = "app"
 
 [tool.setuptools.packages.find]
 where = ["app"]
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.package-data]
+"app" = [
+    "templates/*.html",
+    "static/*.css",
+    "static/*.js",
+]


### PR DESCRIPTION
## Summary
- add a shared `tournament` module so the CLI and web UI reuse the same round-robin logic
- build a Flask application plus HTML/JS/CSS frontend to run tournaments from the browser and visualize standings
- document how to start the web interface and include Flask and static assets in the package metadata

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cf451532dc8325a06cd9ffe0c65eeb