### PR TITLE
Add richer browser UI for configuring tournaments

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -24,6 +24,39 @@ body {
   max-width: 42rem;
 }
 
+.hero-actions {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 32rem;
+}
+
+.hero-actions .cta {
+  align-self: flex-start;
+  border: none;
+  background: linear-gradient(135deg, #7f7bff 0%, #5165ff 100%);
+  color: #fff;
+  border-radius: 999px;
+  padding: 0.65rem 1.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 12px 30px rgba(81, 101, 255, 0.35);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.hero-actions .cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 40px rgba(81, 101, 255, 0.45);
+}
+
+.hero-hint {
+  margin: 0;
+  font-size: 0.95rem;
+  opacity: 0.8;
+}
+
 .container {
   margin: 0 auto;
   padding: 0 1.5rem;
@@ -94,6 +127,20 @@ legend {
   display: flex;
   gap: 0.75rem;
   margin-bottom: 0.75rem;
+}
+
+.strategy-meter {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 1rem 0;
+  color: #4f5d78;
+  font-weight: 500;
+  font-size: 0.9rem;
+}
+
+.strategy-meter .divider {
+  color: rgba(79, 93, 120, 0.6);
 }
 
 .strategy-actions button,
@@ -196,6 +243,62 @@ legend {
   gap: 1.5rem;
 }
 
+.chart {
+  margin-bottom: 1.5rem;
+  background: #fff;
+  border: 1px solid #e3e8f5;
+  border-radius: 0.8rem;
+  padding: 1rem 1.25rem;
+}
+
+.chart h3 {
+  margin: 0 0 0.75rem 0;
+  font-size: 1.1rem;
+}
+
+.chart-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.chart-row {
+  display: grid;
+  grid-template-columns: minmax(140px, 1fr) minmax(0, 220px) auto auto;
+  gap: 0.75rem;
+  align-items: center;
+  font-size: 0.9rem;
+}
+
+.chart-label {
+  font-weight: 600;
+}
+
+.chart-bar {
+  position: relative;
+  background: #dbe1f1;
+  border-radius: 999px;
+  overflow: hidden;
+  height: 0.7rem;
+}
+
+.chart-bar-fill {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(81, 101, 255, 0.9), rgba(122, 132, 255, 0.9));
+  border-radius: inherit;
+}
+
+.chart-score,
+.chart-total {
+  font-variant-numeric: tabular-nums;
+  color: #435167;
+}
+
+.chart-total {
+  text-align: right;
+}
+
 .table-wrapper {
   overflow-x: auto;
 }
@@ -245,5 +348,25 @@ legend {
 
   .card {
     padding: 1.25rem;
+  }
+
+  .chart-row {
+    grid-template-columns: minmax(140px, 1fr);
+    grid-auto-rows: auto;
+  }
+
+  .chart-row .chart-bar,
+  .chart-row .chart-score,
+  .chart-row .chart-total {
+    grid-column: 1 / -1;
+  }
+
+  .chart-row .chart-bar {
+    height: 0.6rem;
+  }
+
+  .chart-row .chart-score,
+  .chart-row .chart-total {
+    text-align: left;
   }
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,6 +11,10 @@
     <div class="container">
       <h1>Iterated Prisoner's Dilemma Tournament</h1>
       <p class="subtitle">Experiment with classic strategies and visualize the results in real time.</p>
+      <div class="hero-actions">
+        <button type="button" class="cta" id="startFormCta">Start a tournament</button>
+        <p class="hero-hint">Pick the programs you want to pit against each other, configure the rules, and watch the standings update instantly.</p>
+      </div>
     </div>
   </header>
 
@@ -47,6 +51,11 @@
             <button type="button" id="selectAll">Select all</button>
             <button type="button" id="clearAll">Clear</button>
           </div>
+          <p class="strategy-meter">
+            <span><strong id="strategyCounter">0</strong> selected</span>
+            <span class="divider" aria-hidden="true">•</span>
+            <span><span id="strategyTotal">0</span> available programs</span>
+          </p>
           <div id="strategiesList" class="strategy-list" aria-live="polite">
             <p class="loading">Loading strategies…</p>
           </div>
@@ -93,7 +102,16 @@
             <strong>Repeats:</strong>
             <span id="summaryRepeats"></span>
           </div>
+          <div>
+            <strong>Top program:</strong>
+            <span id="summaryTopStrategy">—</span>
+          </div>
         </div>
+
+        <section class="chart" aria-label="Average score per round by program">
+          <h3>Performance overview</h3>
+          <div id="standingsChart" class="chart-body"></div>
+        </section>
 
         <div class="tables">
           <div class="table-wrapper">


### PR DESCRIPTION
## Summary
- add a call-to-action hero button and selection meter so visitors can quickly jump into configuring programs
- surface an interactive performance overview chart and top-program summary alongside the results tables
- refresh the styling to support the new layout elements for strategies, charts, and call-to-action content

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cf47cc5004832590783ef8bdb83d50