### PR TITLE
Add media configuration support to CLI and web UI

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -214,6 +214,80 @@ legend {
   font-style: italic;
 }
 
+.media-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+  margin-top: 1rem;
+}
+
+.media-outlet-list {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.media-outlet-item {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+  border: 1px solid #dbe1f1;
+  border-radius: 0.8rem;
+  padding: 0.75rem;
+  background: #f8f9ff;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.media-outlet-item:hover {
+  border-color: #5165ff;
+  box-shadow: 0 10px 25px rgba(81, 101, 255, 0.15);
+}
+
+.media-outlet-item input[type="checkbox"] {
+  margin-top: 0.2rem;
+}
+
+.media-outlet-name {
+  font-weight: 700;
+  display: block;
+}
+
+.media-outlet-meta {
+  font-size: 0.8rem;
+  color: #5a6785;
+  display: block;
+}
+
+.media-subscriptions .table-wrapper {
+  margin-top: 0.5rem;
+}
+
+.media-subscription-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.media-subscription-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: #eef1ff;
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #3d4a62;
+}
+
+.media-subscription-option input[type="checkbox"] {
+  margin: 0;
+}
+
+.media-note[data-status="warning"] {
+  color: #b42318;
+  font-weight: 600;
+}
+
 .actions {
   margin-top: 1.5rem;
 }
@@ -348,6 +422,10 @@ legend {
 
   .card {
     padding: 1.25rem;
+  }
+
+  .media-grid {
+    grid-template-columns: 1fr;
   }
 
   .chart-row {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -79,6 +79,38 @@
           </div>
         </fieldset>
 
+        <fieldset class="media-config" aria-describedby="mediaLimitNote">
+          <legend>Media network</legend>
+          <p class="hint">Choose which outlets broadcast match outcomes and which strategies subscribe to them.</p>
+          <div class="media-grid">
+            <section class="media-outlets">
+              <h3>Outlets</h3>
+              <div id="mediaOutlets" class="media-outlet-list" aria-live="polite">
+                <p class="loading">Loading media configuration…</p>
+              </div>
+            </section>
+            <section class="media-subscriptions">
+              <h3>Subscriptions</h3>
+              <p id="mediaLimitNote" class="hint media-note">Loading…</p>
+              <div class="table-wrapper">
+                <table id="mediaSubscriptionsTable">
+                  <thead>
+                    <tr>
+                      <th scope="col">Strategy</th>
+                      <th scope="col">Subscribed outlets</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td colspan="2" class="hint">Select strategies to configure subscriptions.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          </div>
+        </fieldset>
+
         <div class="actions">
           <button type="submit" id="runButton">Run tournament</button>
         </div>
@@ -105,6 +137,10 @@
           <div>
             <strong>Top program:</strong>
             <span id="summaryTopStrategy">—</span>
+          </div>
+          <div>
+            <strong>Media reports delivered:</strong>
+            <span id="summaryMediaReports">0</span>
           </div>
         </div>
 
@@ -147,6 +183,24 @@
               <tbody></tbody>
             </table>
             <p class="hint" id="matchHint"></p>
+          </div>
+          <div class="table-wrapper">
+            <h3>Media reports</h3>
+            <table id="mediaTable">
+              <thead>
+                <tr>
+                  <th scope="col">Strategy</th>
+                  <th scope="col">Outlet</th>
+                  <th scope="col">Rep</th>
+                  <th scope="col">Match</th>
+                  <th scope="col">Accurate</th>
+                  <th scope="col">Rumor</th>
+                  <th scope="col">Delay</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+            <p class="hint" id="mediaHint"></p>
           </div>
         </div>
       </div>

--- a/app/tournament.py
+++ b/app/tournament.py
@@ -89,6 +89,7 @@ def run_tournament(
             media_network.set_rng(rng)
         else:
             media_network = MediaNetwork.from_config(media, rng=rng)
+        media_network.reset_logs()
 
     for rep in range(max(1, repeats)):
         players = [cls() for cls in strategy_classes]
@@ -176,4 +177,6 @@ def run_tournament(
         "matches": matches,
         "standings": standings,
     }
+    if media_network:
+        result["media"] = media_network.export_state()
     return result

--- a/app/web.py
+++ b/app/web.py
@@ -8,6 +8,23 @@ from flask import Flask, jsonify, render_template, request
 
 from .engine import Payoffs
 from .tournament import list_available_strategies, run_tournament
+from .media import (
+    DEFAULT_MEDIA_PRESET,
+    MEDIA_PRESETS,
+    clone_media_config,
+    resolve_media_config,
+)
+
+
+def _default_media_config() -> Dict[str, Any]:
+    try:
+        config = resolve_media_config(DEFAULT_MEDIA_PRESET)
+        if config is None:
+            return {}
+        return config
+    except Exception:
+        preset = MEDIA_PRESETS.get(DEFAULT_MEDIA_PRESET, {})
+        return clone_media_config(preset)
 
 
 def create_app() -> Flask:
@@ -15,11 +32,19 @@ def create_app() -> Flask:
 
     @app.get("/")
     def index() -> str:
-        return render_template("index.html")
+        return render_template("index.html", media_presets=sorted(MEDIA_PRESETS.keys()))
 
     @app.get("/api/strategies")
     def api_strategies():
-        return jsonify({"strategies": list_available_strategies()})
+        return jsonify(
+            {
+                "strategies": list_available_strategies(),
+                "media": {
+                    "config": clone_media_config(_default_media_config()),
+                    "presets": sorted(MEDIA_PRESETS.keys()),
+                },
+            }
+        )
 
     @app.post("/api/run")
     def api_run():
@@ -43,6 +68,11 @@ def create_app() -> Flask:
             selected = payload.get("strategies") or None
             exclude = payload.get("exclude") or None
 
+            media_spec = payload.get("media")
+            media_config = None
+            if media_spec not in (None, "", {}):
+                media_config = resolve_media_config(media_spec)
+
             result = run_tournament(
                 rounds=rounds,
                 continuation=continuation,
@@ -52,8 +82,11 @@ def create_app() -> Flask:
                 payoffs=payoffs,
                 only=selected,
                 exclude=exclude,
+                media=media_config,
             )
         except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+        except TypeError as exc:
             return jsonify({"error": str(exc)}), 400
         except Exception as exc:  # pragma: no cover - generic safeguard
             return jsonify({"error": "Failed to run tournament", "details": str(exc)}), 500


### PR DESCRIPTION
## Summary
- add media configuration presets and subscription handling to the media network and tournament results
- extend the CLI with a --media-config option and export media report logs in CSV/JSON outputs
- update the Flask API, template, styles, and client-side script to configure outlets/subscriptions and display delivered media reports

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d167c606508325bb120d6465b4ab51