### PR TITLE
Document media layer and add sample outlet configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,92 @@ The web UI lets you pick strategies, tweak tournament parameters, and view stand
 - `--format`: Output format. csv or json. Default csv
 - `--labels`: Print strategy descriptions and exit
 
+## Media layer overview
+
+The tournament engine can simulate a lightweight media network that reports
+match outcomes to participating strategies. Each **outlet** advertises:
+
+* `coverage` – probability an outlet reports on a particular match
+* `accuracy` – probability the report mirrors the real outcome (otherwise a rumour is broadcast)
+* `delay` – number of tournament ticks before the report is delivered (integer or list)
+
+Strategies can optionally subscribe to outlets via enrollment rules that limit
+the number of feeds each player follows. The CLI ships with two built-in
+presets (`none` and `basic`) and accepts arbitrary JSON describing the network.
+
+### Configuration examples
+
+Example configurations live in `outlets/`. The `balanced.json` preset
+demonstrates a mix of highly accurate but slower outlets alongside more
+speculative sources:
+
+```json
+{
+  "outlets": [
+    {"name": "GlobalTruth", "coverage": 0.8, "accuracy": 0.97, "delay": [0, 1]},
+    {"name": "RegionalObserver", "coverage": 0.65, "accuracy": 0.9, "delay": [1, 2]},
+    {"name": "QuickTake", "coverage": 0.45, "accuracy": 0.7, "delay": [0, 1, 2, 3]}
+  ],
+  "subscriptions": {
+    "limit": 2,
+    "defaults": {
+      "TitForTat": ["GlobalTruth"],
+      "WinStayLoseShift": ["GlobalTruth", "RegionalObserver"],
+      "Random": ["QuickTake"]
+    }
+  }
+}
+```
+
+Run a tournament with that network by piping the JSON to `--media-config`:
+
+```bash
+docker compose --profile cli run --rm pd \
+  --media-config "$(cat outlets/balanced.json)" \
+  --rounds 200 --seed 42
+```
+
+For a more sensational environment with high coverage but lower accuracy, try
+`outlets/sensational.json`. The CLI help text lists built-in presets and points
+to the directory of ready-made samples.
+
+### Strategies that react to media
+
+Strategies inherit from `BaseStrategy`, which provides a `receive_media`
+callback invoked whenever an enrolled outlet publishes a story. The default
+implementation records reports in the `.rumors` list so strategies can inspect
+them from `decide`:
+
+```python
+from .base import BaseStrategy
+
+class ReactiveTitForTat(BaseStrategy):
+    """Punish if a trusted outlet reports betrayal."""
+
+    def reset(self):
+        super().reset()
+        self._betrayed = False
+
+    def receive_media(self, report):
+        if not report.accurate:
+            return
+        players = report.payload["players"]
+        histories = report.payload["history"]
+        opponent = players["A"] if players["B"] == self.name() else players["B"]
+        if histories.get(opponent, "").endswith("D"):
+            self._betrayed = True
+
+    def decide(self, my_history, opp_history, round_index):
+        if self._betrayed:
+            return "D"
+        return "D" if opp_history and opp_history[-1] == "D" else "C"
+```
+
+Use `reset` for per-match cleanup and `media_reset` if you also need to clear
+state between tournaments. Always guard against rumours by checking
+`report.accurate` or other payload fields that outlets may swap when accuracy
+rolls fail.
+
 ## Add your own strategy
 
 Create a new file in `app/strategies/` and implement a class deriving from `BaseStrategy`.
@@ -84,6 +170,17 @@ docker compose build
 - `app/engine.py` tournament logic
 - `app/strategies/` built-in strategies
 - `out/` results mounted outside the container
+
+## Developer notes
+
+* The CLI `--seed` option seeds the tournament RNG and is forwarded into the
+  `MediaNetwork`, so identical seeds reproduce outlet coverage/accuracy rolls
+  and the resulting rumour cascades. When writing your own scripts call
+  `run_tournament(..., rng=random.Random(seed))` or pass a seeded `random.Random`
+  instance into `MediaNetwork.from_config` to mirror CLI behaviour.
+* Outlets draw all randomness from the shared RNG; match continuation checks do
+  as well. If you also rely on noisy moves, seed Python's global RNG with the
+  same value before running a tournament to mirror CLI runs exactly.
 
 ## License
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -36,8 +36,11 @@ def main():
         "--media-config",
         type=str,
         default="",
-        help="JSON string or preset name for media network configuration"
-        f" (presets: {', '.join(sorted(MEDIA_PRESETS))})",
+        help=(
+            "JSON string or preset name for media network configuration "
+            f"(presets: {', '.join(sorted(MEDIA_PRESETS))}; "
+            "see outlets/*.json for coverage vs. accuracy examples)"
+        ),
     )
     parser.add_argument("--labels", action="store_true", help="List strategy names and exit")
     args = parser.parse_args()

--- a/outlets/balanced.json
+++ b/outlets/balanced.json
@@ -1,0 +1,30 @@
+{
+  "outlets": [
+    {
+      "name": "GlobalTruth",
+      "coverage": 0.8,
+      "accuracy": 0.97,
+      "delay": [0, 1]
+    },
+    {
+      "name": "RegionalObserver",
+      "coverage": 0.65,
+      "accuracy": 0.9,
+      "delay": [1, 2]
+    },
+    {
+      "name": "QuickTake",
+      "coverage": 0.45,
+      "accuracy": 0.7,
+      "delay": [0, 1, 2, 3]
+    }
+  ],
+  "subscriptions": {
+    "limit": 2,
+    "defaults": {
+      "TitForTat": ["GlobalTruth"],
+      "WinStayLoseShift": ["GlobalTruth", "RegionalObserver"],
+      "Random": ["QuickTake"]
+    }
+  }
+}

--- a/outlets/sensational.json
+++ b/outlets/sensational.json
@@ -1,0 +1,31 @@
+{
+  "outlets": [
+    {
+      "name": "ViralNow",
+      "coverage": 0.95,
+      "accuracy": 0.45,
+      "delay": [0]
+    },
+    {
+      "name": "FactFocus",
+      "coverage": 0.5,
+      "accuracy": 0.99,
+      "delay": [2, 3, 4]
+    },
+    {
+      "name": "EchoSphere",
+      "coverage": 0.75,
+      "accuracy": 0.6,
+      "delay": [0, 1, 2]
+    }
+  ],
+  "subscriptions": {
+    "limit": 1,
+    "defaults": {
+      "TitForTat": ["FactFocus"],
+      "GrimTrigger": ["FactFocus"],
+      "Random": ["ViralNow"],
+      "Defector": ["ViralNow"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- document the media network workflow, example configuration usage, and media-reactive strategy guidance in the README
- add developer notes on RNG seeding behaviour for reproducible rumor cascades
- provide example outlet JSON configurations and reference them from the CLI help text

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d176f7200083258404b8463614bb18