### PR TITLE
Add automatic media subscriptions for media-aware strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,7 @@ speculative sources:
   ],
   "subscriptions": {
     "limit": 2,
-    "defaults": {
-      "TitForTat": ["GlobalTruth"],
-      "WinStayLoseShift": ["GlobalTruth", "RegionalObserver"],
-      "Random": ["QuickTake"]
-    }
+    "defaults": {}
   }
 }
 ```
@@ -111,7 +107,9 @@ to the directory of ready-made samples.
 Strategies inherit from `BaseStrategy`, which provides a `receive_media`
 callback invoked whenever an enrolled outlet publishes a story. The default
 implementation records reports in the `.rumors` list so strategies can inspect
-them from `decide`:
+them from `decide`. Strategies that want to auto-enrol with outlets can also
+override `preferred_media_outlets`, which receives the available `MediaOutlet`
+instances and returns outlet names ordered by preference:
 
 ```python
 from .base import BaseStrategy
@@ -154,6 +152,10 @@ actively digest media coverage:
   coverage and borrows their latest move as its preferred opening.
 * **MediaWatchdog** – Monitors outlet accuracy and toggles between a strict grim
   trigger and a generous mode depending on how trustworthy the network appears.
+
+These strategies advertise their preferred outlets through
+`preferred_media_outlets`, allowing tournaments to auto-enrol them without user
+intervention while traditional strategies remain media agnostic.
 
 ## Add your own strategy
 

--- a/app/strategies/base.py
+++ b/app/strategies/base.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List, TYPE_CHECKING
+from typing import List, Sequence, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ..media import MediaReport
+    from ..media import MediaOutlet, MediaReport
 
 class BaseStrategy(ABC):
     """
@@ -37,6 +37,16 @@ class BaseStrategy(ABC):
         """Return the rumors observed by this strategy since the last reset."""
 
         return list(self._rumors)
+
+    def preferred_media_outlets(self, outlets: Sequence["MediaOutlet"]) -> Sequence[str]:
+        """Return outlet names this strategy wishes to follow by default.
+
+        Base strategies return an empty sequence, leaving enrollment control to
+        tournament configuration. Media-aware strategies can override this to
+        express automatic subscriptions derived from outlet attributes.
+        """
+
+        return ()
 
     @abstractmethod
     def decide(self, my_history, opp_history, round_index: int) -> str:

--- a/outlets/balanced.json
+++ b/outlets/balanced.json
@@ -21,10 +21,6 @@
   ],
   "subscriptions": {
     "limit": 2,
-    "defaults": {
-      "TitForTat": ["GlobalTruth"],
-      "WinStayLoseShift": ["GlobalTruth", "RegionalObserver"],
-      "Random": ["QuickTake"]
-    }
+    "defaults": {}
   }
 }

--- a/outlets/sensational.json
+++ b/outlets/sensational.json
@@ -21,11 +21,6 @@
   ],
   "subscriptions": {
     "limit": 1,
-    "defaults": {
-      "TitForTat": ["FactFocus"],
-      "GrimTrigger": ["FactFocus"],
-      "Random": ["ViralNow"],
-      "Defector": ["ViralNow"]
-    }
+    "defaults": {}
   }
 }


### PR DESCRIPTION
## Summary
- allow strategies to advertise preferred media outlets through a new `preferred_media_outlets` hook on `BaseStrategy`
- give media-aware strategies heuristics to auto-enrol with outlets and let the media network respect those selections while preserving manual overrides
- refresh media presets, sample configs, and docs to reflect automatic subscriptions rather than user-assigned defaults

## Testing
- python -m compileall app


------
https://chatgpt.com/codex/tasks/task_e_68d2aa365dcc8325adb3f9e99774476c